### PR TITLE
dev-test: use one $GOPATH instead of Godeps

### DIFF
--- a/scripts/dev-test
+++ b/scripts/dev-test
@@ -3,15 +3,33 @@
 set -e -x
 
 DEV_GOPATH=$(cd ${1:-$HOME/go} && pwd)
+TMP_GOPATH=/tmp/inigo
 
-TMP_GOPATH=$(mktemp -d /tmp/diego-release-gopath.XXXXX)
+mkdir -p ${TMP_GOPATH}
 
 cp $(dirname $0)/.drone.yml ${TMP_GOPATH}/.drone.yml
 
 function copy_to_gopath {
-  mkdir -p ${TMP_GOPATH}/src/$(dirname $1)
-  cp -a ${DEV_GOPATH}/src/${1} ${TMP_GOPATH}/src/${1}
+  mkdir -p ${TMP_GOPATH}/src/${1}
+  rsync -a ${DEV_GOPATH}/src/${1}/ ${TMP_GOPATH}/src/${1}/
 }
+
+(
+  set -e -x
+
+  cd $TMP_GOPATH
+
+  godep save \
+    github.com/cloudfoundry-incubator/inigo/...\
+    github.com/cloudfoundry-incubator/executor/... \
+    github.com/cloudfoundry-incubator/stager/... \
+    github.com/cloudfoundry-incubator/file-server/... \
+    github.com/cloudfoundry-incubator/linux-smelter/... \
+    github.com/pivotal-cf-experimental/garden/...
+
+  mv Godeps/_workspace/src src
+  rm -rf Godeps
+)
 
 # grab and set up our components
 for package in \
@@ -21,14 +39,16 @@ for package in \
     github.com/cloudfoundry-incubator/file-server \
     github.com/cloudfoundry-incubator/linux-smelter \
     github.com/pivotal-cf-experimental/garden; do
-  copy_to_gopath $package
+  copy_to_gopath $package &
 done
 
 # install application dependencies
 for package in github.com/coreos/etcd github.com/apcera/gnatsd; do
-  copy_to_gopath $package
+  copy_to_gopath $package &
 done
 
-cp -a ~/workspace/loggregator ${TMP_GOPATH}/loggregator
+rsync -a ~/workspace/loggregator ${TMP_GOPATH}/loggregator &
+
+wait
 
 drone -privileged build $TMP_GOPATH

--- a/scripts/dev-test-inner
+++ b/scripts/dev-test-inner
@@ -4,20 +4,16 @@ set -e -x
 
 GOPATH_ROOT=$PWD
 
-export GOPATH=$GOPATH_ROOT
-export PATH=$GOPATH_ROOT/bin:$PATH
-
-# set up inigo's own dependencies
-export GOPATH=${GOPATH}:${GOPATH_ROOT}/src/github.com/cloudfoundry-incubator/inigo/Godeps/_workspace
-export PATH=${GOPATH_ROOT}/src/github.com/cloudfoundry-incubator/inigo/Godeps/_workspace/bin:${PATH}
+export GOPATH=${GOPATH_ROOT}
+export PATH=${GOPATH_ROOT}/bin:${PATH}
 
 # set up compile-time $GOPATHs for each component
 export LOGGREGATOR_GOPATH=${GOPATH_ROOT}/loggregator
-export EXECUTOR_GOPATH=${GOPATH_ROOT}/src/github.com/cloudfoundry-incubator/executor/Godeps/_workspace:${GOPATH_ROOT}
-export STAGER_GOPATH=${GOPATH_ROOT}/src/github.com/cloudfoundry-incubator/stager/Godeps/_workspace:${GOPATH_ROOT}
-export FILE_SERVER_GOPATH=${GOPATH_ROOT}/src/github.com/cloudfoundry-incubator/file-server/Godeps/_workspace:${GOPATH_ROOT}
-export LINUX_SMELTER_GOPATH=${GOPATH_ROOT}/src/github.com/cloudfoundry-incubator/linux-smelter/Godeps/_workspace:${GOPATH_ROOT}
-export GARDEN_GOPATH=${GOPATH_ROOT}/src/github.com/pivotal-cf-experimental/garden/Godeps/_workspace:${GOPATH_ROOT}
+export EXECUTOR_GOPATH=${GOPATH_ROOT}
+export STAGER_GOPATH=${GOPATH_ROOT}
+export FILE_SERVER_GOPATH=${GOPATH_ROOT}
+export LINUX_SMELTER_GOPATH=${GOPATH_ROOT}
+export GARDEN_GOPATH=${GOPATH_ROOT}
 
 # install application dependencies
 for package in github.com/coreos/etcd github.com/apcera/gnatsd; do


### PR DESCRIPTION
This is more convenient for development when you're working on/adding
debugging to a libary and just want to run Inigo.

Also, rsync most code in parallel.
