### PR TITLE
Add buildpack_key to staging response

### DIFF
--- a/stager_test.go
+++ b/stager_test.go
@@ -207,7 +207,10 @@ EOF
 				Eventually(payloads, LONG_TIMEOUT).Should(Receive(&payload))
 
 				//Assert on the staging output (detected buildpack)
-				Ω(string(payload)).Should(Equal(`{"detected_buildpack":"My Buildpack"}`))
+				Ω(string(payload)).Should(MatchJSON(`{
+					"buildpack_key":"test-buildpack",
+					"detected_buildpack":"My Buildpack"
+				}`))
 
 				//Asser the user saw reasonable output
 				Eventually(logOutput).Should(gbytes.Say("COMPILING BUILDPACK"))


### PR DESCRIPTION
Carry `buildpack_key` back to the cloud controller in the staging response.

Depends on:
cloudfoundry-incubator/runtime-schema#6
cloudfoundry-incubator/linux-smelter#5
cloudfoundry-incubator/stager#2
