### PR TITLE
Update inigo's path for building gorouter

### DIFF
--- a/cell/cell_suite_test.go
+++ b/cell/cell_suite_test.go
@@ -208,7 +208,7 @@ func CompileTestedExecutables() world.BuiltExecutables {
 
 	if runtime.GOOS != "windows" {
 		Expect(os.Chdir(os.Getenv("ROUTER_GOPATH"))).To(Succeed())
-		builtExecutables["router"], err = gexec.Build("code.cloudfoundry.org/gorouter", "-race")
+		builtExecutables["router"], err = gexec.Build("code.cloudfoundry.org/gorouter/cmd/gorouter", "-race")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.Chdir(cwd)).To(Succeed())
 	}

--- a/volman/volman_suite_test.go
+++ b/volman/volman_suite_test.go
@@ -181,7 +181,7 @@ func CompileTestedExecutables() world.BuiltExecutables {
 	Expect(err).NotTo(HaveOccurred())
 
 	Expect(os.Chdir(os.Getenv("ROUTER_GOPATH"))).To(Succeed())
-	builtExecutables["router"], err = gexec.Build("code.cloudfoundry.org/gorouter", "-race")
+	builtExecutables["router"], err = gexec.Build("code.cloudfoundry.org/gorouter/cmd/gorouter", "-race")
 	Expect(err).NotTo(HaveOccurred())
 	Expect(os.Chdir(cwd)).To(Succeed())
 


### PR DESCRIPTION

### What is this change about?

Fixes inigo's ability to build gorouter binaries after we moved the main.go file path.